### PR TITLE
Migrate to SDL3, bump eden to 2026-05-18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ handoffs/
 deferred-work.jsonl
 __pycache__/
 *.pyc
+
+# sync-deps.py machine-readable run report (local only)
+.sync-output.json

--- a/deps/default.nix
+++ b/deps/default.nix
@@ -135,4 +135,12 @@
     url = "https://github.com/arun11299/cpp-jwt/archive/7f24eb4c32.tar.gz";
     hash = "sha256-qYgUTWKJAXDhDgkt3Y00QPyIkCalyZFH+dbF17CZGnE=";
   };
+
+  # sdl3 - windowing/input/audio (eden migrated SDL2 -> SDL3, 2026-05).
+  # Built from source; eden has no system-SDL3 path. Tag tracks the
+  # cpmfile.json `git_version` (3.4.8), maintained by scripts/sync-deps.py.
+  sdl3 = pkgs.fetchzip {
+    url = "https://github.com/libsdl-org/SDL/archive/refs/tags/release-3.4.8.tar.gz";
+    hash = "sha256-uBGyGxrUVx642Ku8qhR2sTy2JagcSioIhh/5RsXVAIM=";
+  };
 }

--- a/package.nix
+++ b/package.nix
@@ -24,7 +24,6 @@
   lz4,
   nlohmann_json,
   openssl,
-  SDL2,
   zlib,
   zstd,
   libzip,
@@ -34,13 +33,32 @@
   alsa-lib,
   libpulseaudio,
   pipewire,
+  # SDL3 build deps — eden bundles + builds SDL3 from source (no system path)
+  dbus,
+  libGL,
+  libdrm,
+  libxkbcommon,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+  libdecor,
+  udev,
+  libx11,
+  libxext,
+  libxcursor,
+  libxi,
+  libxrandr,
+  libxfixes,
+  libxscrnsaver,
+  libxcb,
+  libxtst,
 }:
 
 let
   # Auto-updated by GitHub Actions - do not edit manually
-  # Last updated: 2026-03-24
-  rev = "8f770618d27a053b8ce70e7fd5e699885e23325e";
-  version = "0.2.0-rc2-unstable-2026-03-24";
+  # Last updated: 2026-05-18
+  rev = "e875a3196b5fc525f357b387d3cb2f283b11b8a0";
+  version = "0.2.0-rc2-unstable-2026-05-18";
 in
 stdenv.mkDerivation {
   pname = "eden";
@@ -51,7 +69,7 @@ stdenv.mkDerivation {
     owner = "eden-emu";
     repo = "eden";
     inherit rev;
-    hash = "sha256-Ecqt94ih7dlkzGqmfou3hT0WcLERoqs8NgBZ3RDA4ns=";
+    hash = "sha256-6YlRa4DvaXq56HJmmE+zYkSpPHPcV+s91FxYGZ1KeHU=";
     fetchSubmodules = true;
   };
 
@@ -64,6 +82,7 @@ stdenv.mkDerivation {
     qt6Packages.qttools
     glslang
     protobuf
+    wayland-scanner
   ];
 
   buildInputs = [
@@ -90,7 +109,6 @@ stdenv.mkDerivation {
     nv-codec-headers-12
     protobuf
     openssl
-    SDL2
     zlib
     zstd
 
@@ -98,6 +116,25 @@ stdenv.mkDerivation {
     alsa-lib
     libpulseaudio
     pipewire
+
+    # SDL3 build deps — eden builds the bundled SDL3 source
+    dbus
+    libGL
+    libdrm
+    libxkbcommon
+    wayland
+    wayland-protocols
+    libdecor
+    udev
+    libx11
+    libxext
+    libxcursor
+    libxi
+    libxrandr
+    libxfixes
+    libxscrnsaver
+    libxcb
+    libxtst
   ];
 
   # Pre-populate CPM cache with our pre-fetched deps
@@ -145,6 +182,7 @@ stdenv.mkDerivation {
     copyDep ${deps.libusb} libusb/1.0.29
     copyDep ${deps.httplib} httplib/0.37.0
     copyDep ${deps.cpp-jwt} cpp-jwt/7f24
+    copyDep ${deps.sdl3} sdl3/3.4.8
 
     # Archives that need extraction (fetchurl - not directories)
     extractDep ${deps.mbedtls} mbedtls/3.6.4
@@ -181,10 +219,8 @@ stdenv.mkDerivation {
     "-DYUZU_USE_QT_MULTIMEDIA=ON"
     "-DYUZU_USE_QT_WEB_ENGINE=ON"
 
-    # SDL2 - use system
-    "-DENABLE_SDL2=ON"
-    "-DYUZU_USE_EXTERNAL_SDL2=OFF"
-    "-DYUZU_USE_BUNDLED_SDL2=OFF"
+    # SDL3 - built from the bundled CPM source (externals/cpmfile.json)
+    "-DYUZU_USE_BUNDLED_SDL3=OFF"
 
     # FFmpeg - use system
     "-DYUZU_USE_BUNDLED_FFMPEG=OFF"

--- a/package.nix
+++ b/package.nix
@@ -242,8 +242,8 @@ stdenv.mkDerivation {
   ];
 
   postInstall = ''
-    # Install udev rules for controller support (upstream still uses yuzu naming)
-    install -Dm644 $src/dist/72-yuzu-input.rules $out/lib/udev/rules.d/72-eden-input.rules
+    # Install udev rules for controller support
+    install -Dm644 $src/dist/72-eden-input.rules $out/lib/udev/rules.d/72-eden-input.rules
 
     # Install desktop file, icon, and appstream metadata (CMake doesn't install these)
     install -Dm644 $src/dist/dev.eden_emu.eden.desktop $out/share/applications/dev.eden_emu.eden.desktop


### PR DESCRIPTION
## What

eden `2026-05-18` migrated SDL2 → SDL3. SDL3 has no system path in eden's
CMake (`externals/CMakeLists.txt` always `AddJsonPackage(sdl3)`), so
eden-nix must bundle + build SDL3 from source.

- `deps/default.nix`: add `sdl3` — `libsdl-org/SDL` `release-3.4.8`, the
  tag derived from `externals/cpmfile.json`'s `git_version` (the value
  `scripts/sync-deps.py` computes), so it stays auto-maintained.
- `package.nix`: bundle SDL3 into the CPM cache (`sdl3/3.4.8`); drop
  system SDL2 + the obsolete `*_SDL2` cmake flags; add SDL3's build deps
  (X11 / Wayland / dbus / libdrm / libGL / libxkbcommon / udev /
  libdecor + `wayland-scanner`); bump rev/version/hash to 2026-05-18.
- `.gitignore`: ignore `sync-deps.py`'s `.sync-output.json`.

## Why a branch/PR

The full eden compile is delegated to CI. Landing via a PR keeps
`main` green until CI confirms the SDL3 build.

Resolves the SDL2→SDL3 blocker from issue #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)